### PR TITLE
Read more EDF files

### DIFF
--- a/ctd/ctd.py
+++ b/ctd/ctd.py
@@ -130,7 +130,7 @@ def from_edf(fname, compression=None, below_water=False, lon=None,
             break
 
     f.seek(0)
-    cast = read_table(f, header=None, index_col=None, names=names, dtype=float,
+    cast = read_table(f, header=None, index_col=None, names=names,
                       skiprows=skiprows, delim_whitespace=True)
     f.close()
 


### PR DESCRIPTION
I have EDF files that contain a "Latitude: " header but then no value, and are not only float data.
The from_edf function had a lat and lon argument that were not used. Now, if lat or lon is passed in, it is not read from the file. Also, read_table does not assume everything is float.
