### PR TITLE
added 'pr' to pressure field #20

### DIFF
--- a/ctd/ctd.py
+++ b/ctd/ctd.py
@@ -199,7 +199,7 @@ def from_cnv(fname, compression=None, below_water=False, lon=None,
     f.close()
 
     key_set = False
-    prkeys = ['prDM', 'prdM']
+    prkeys = ['prDM', 'prdM', 'pr']
     for prkey in prkeys:
         try:
             cast.set_index(prkey, drop=True, inplace=True)


### PR DESCRIPTION
on line 202 of ctd/ctd.py we added 'pr' to the possible pressure field names, so it is compatible with older models of the SeaBird MicroCat.