### PR TITLE
fix for pandas 1.0 dup col drop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
+dist: xenial
+
 language: python
 
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - xvfb
+services:
+  - xvfb
 
 env:
   global:
     - secure: "Tlgd7sOn9XoITQ69wWen9XLLzVqz8IXKtA4B+KXaRP6vTliP6XPrEDldOrOkNYwQFE7P5p57H3irp2fMLIsvxd2JEuN17i+6flB5JrBX+YmVV6tQ/DdDHUUc55CmO1bJefNpWK3kc/Z3TXdKA1k881sTGe/0BHTHV73CYj9ARrs="
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 5 # give xvfb some time to start
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
It is common for seabird CTDs to duplicate the `scan` column. In the past pandas allowed that but latest pandas 1.0 fails, as expected, when this occurs.

We decided to allow for 1 duplication and will append `_` to the column name. More than 1 duplication will throw an error.