### PR TITLE
Remove up to a certain index value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,8 @@ before_install:
     export PATH="$HOME/miniconda/bin:$PATH"
     conda config --set always_yes yes --set changeps1 no --set show_channel_urls true
     conda update conda --quiet
-    conda install pycryptosat --quiet
     conda config --add channels conda-forge --force
     conda config --set channel_priority strict
-    conda config --set safety_checks disabled
     conda create --name TEST python=$PY --file requirements.txt --file requirements-dev.txt
     source activate TEST
 

--- a/ctd/processing.py
+++ b/ctd/processing.py
@@ -19,8 +19,17 @@ def _rolling_window(data, block):
 @register_series_method
 @register_dataframe_method
 def remove_above_water(df):
+    return remove_up_to(df, idx=0)
+
+
+@register_series_method
+@register_dataframe_method
+def remove_up_to(df, idx):
+    """
+    Remove all the data above a certain index value where index can be pressure or depth.
+    """
     new_df = df.copy()
-    return new_df[new_df.index >= 0]
+    return new_df[new_df.index >= idx]
 
 
 @register_series_method

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -27,6 +27,18 @@ def test_remove_above_water_df(df):
     assert not any(df.remove_above_water().index < 0)
 
 
+def test_remove_up_to_series(series):
+    idx = 10
+    assert any(series.index < idx)
+    assert not any(series.remove_up_to(idx=idx).index < idx)
+
+
+def test_remove_up_to_df(df):
+    idx = 10
+    assert any(df.index < idx)
+    assert not any(df.remove_up_to(idx=idx).index < idx)
+
+
 def test_split_series(series):
     splitted = series.split()
     down, up = splitted


### PR DESCRIPTION
Remove above water is not enough for some problematic casts. This add a convenience method to remove data up to an arbitrary pressure/depth level.