### PR TITLE
Update read.py

### DIFF
--- a/ctd/read.py
+++ b/ctd/read.py
@@ -405,6 +405,7 @@ def from_cnv(fname):
 
     prkeys = [
         "prM ",
+        "prM",
         "prE",
         "prDM",
         "pr50M",
@@ -416,8 +417,12 @@ def from_cnv(fname):
         "prDE",
     ]
     prkey = [key for key in prkeys if key in df.columns]
-    if len(prkey) != 1:
-        raise ValueError(f"Expected one pressure/depth column, got {prkey}.")
+    if len(prkey) ==0:
+        raise ValueError(f"Expected one pressure/depth column, didn't receive any")
+    elif len(prkey) >1:
+        #if multiple keys present then keep the first one 
+        prkey=prkey[0]
+
     df.set_index(prkey, drop=True, inplace=True)
     df.index.name = "Pressure [dbar]"
     if prkey == "depSM":


### PR DESCRIPTION
update the from_cnv reading options to include "prM" without a space as a key, update the prkey error conditional statements to be able to read files that may have more than 1 key (such as both depth and pressure)