### PR TITLE
Fix bottle oldest bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.9
+  rev: v0.15.12
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]
@@ -62,12 +62,12 @@ repos:
     - id: nb-strip-paths
 
 - repo: https://github.com/tox-dev/pyproject-fmt
-  rev: v2.21.0
+  rev: v2.21.2
   hooks:
     - id: pyproject-fmt
 
 - repo: https://github.com/woodruffw/zizmor-pre-commit
-  rev: v1.23.1
+  rev: v1.24.1
   hooks:
     - id: zizmor
 

--- a/ctd/read.py
+++ b/ctd/read.py
@@ -86,6 +86,8 @@ def _read_file(fname: str | Path | StringIO) -> StringIO:
         )
     # Read as bytes but we need to return strings for the parsers.
     encoding = chardet.detect(contents)["encoding"]
+    if encoding is None:
+        encoding = "utf-8"
     text = contents.decode(encoding=encoding, errors="replace")
     return StringIO(text)
 
@@ -418,16 +420,27 @@ def from_cnv(fname: str | Path) -> pd.DataFrame:
     metadata = _parse_seabird(f.readlines(), ftype="cnv")
 
     f.seek(0)
-    cast = pd.read_fwf(
-        f,
-        header=None,
-        index_col=None,
-        names=metadata["names"],
-        skiprows=metadata["skiprows"],
-        sep=r"\s+",
-        widths=[11] * len(metadata["names"]),
-    )
+    lines = f.readlines()[metadata["skiprows"] :]
     f.close()
+
+    data = [line.strip().split() for line in lines]
+    cast = pd.DataFrame(
+        data,
+        columns=metadata["names"],
+    )
+
+    dtypes = {"bpos": int, "pumps": bool, "flag": bool}
+    for column in cast.columns:
+        if column in dtypes:
+            cast[column] = cast[column].astype(dtypes[column])
+        else:
+            try:
+                cast[column] = pd.to_numeric(cast[column], errors="coerce")
+            except ValueError:
+                warnings.warn(
+                    f"Could not convert {column} to float.",
+                    stacklevel=2,
+                )
 
     prkeys = [
         "prM",
@@ -475,19 +488,6 @@ def from_cnv(fname: str | Path) -> pd.DataFrame:
     if "name" not in metadata:
         name = _basename(fname)[1]
         metadata["name"] = str(name)
-
-    dtypes = {"bpos": int, "pumps": bool, "flag": bool}
-    for column in cast.columns:
-        if column in dtypes:
-            cast[column] = cast[column].astype(dtypes[column])
-        else:
-            try:
-                cast[column] = cast[column].astype(float)
-            except ValueError:
-                warnings.warn(
-                    f"Could not convert {column} to float.",
-                    stacklevel=2,
-                )
 
     cast._metadata = metadata  # noqa: SLF001
     return cast

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chardet
+chardet<7
 gsw>=3.3.0
 matplotlib
 numpy>=2


### PR DESCRIPTION
The long term goal should be replace the custom pandas reader with `seabirdfilehandler`, until then I'm just updating to ensure pandas `infer` columns is used to avoid getting the wrong values in bottle ros files.

I'm also using coerce to numeric instead of a more error tolerant way to ensure malformed files can e partially read. The user can figure out why they are getting NaNs by comparing with the original values. 